### PR TITLE
Adapt to REPL changes planned for Scala 2.12.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3176,6 +3176,22 @@
       </repositories>
     </profile>
 
+    <profile>
+      <id>scala-pr-validation-snapshots</id>
+      <repositories>
+       <repository>
+          <id>scala-pr-validation-snapshots</id>
+          <url>https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+        </repository>
+      </repositories>
+    </profile>
+
     <!--
       These empty profiles are available in some sub-modules. Declare them here so that
       maven does not complain when they're provided on the command line for a sub-module

--- a/repl/src/main/scala/org/apache/spark/repl/Main.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/Main.scala
@@ -74,6 +74,16 @@ object Main extends Logging {
     val settings = new GenericRunnerSettings(scalaOptionError)
     settings.processArguments(interpArguments, true)
 
+    // Support Scala 2.12.10 and 2.12.11. The latter introduces `-Yrepl-use-magic-imports` and Spark
+    // requires that to be enabled to take advantage of the dead code eliminiation now in `-Yclass-based`
+    // that solves https://issues.apache.org/jira/browse/SPARK-5150.
+    //
+    // See https://github.com/scala/scala/pull/8576
+    // See https://github.com/scala/scala/pull/8712
+    //
+    // TODO: Move the setting into the list above once support for 2.12.10 and below is dropped.
+    settings.processArguments("-Yrepl-use-magic-imports" :: Nil, processAll = false)
+
     if (!hasErrors) {
       interp.process(settings) // Repl starts and goes in loop of R.E.P.L
       Option(sparkContext).foreach(_.stop)


### PR DESCRIPTION
The renovations of `-Yrepl-class-based` (https://github.com/scala/scala/pull/8712) require opting into the the newly added `-Yrepl-use-magic-imports` (https://github.com/scala/scala/pull/8576).
